### PR TITLE
Fix: Add safeguards against division by zero in LDA

### DIFF
--- a/sklearn/discriminant_analysis.py
+++ b/sklearn/discriminant_analysis.py
@@ -552,9 +552,18 @@ class LinearDiscriminantAnalysis(
         Sb = St - Sw  # between scatter
 
         evals, evecs = linalg.eigh(Sb, Sw)
-        self.explained_variance_ratio_ = np.sort(evals / np.sum(evals))[::-1][
-            : self._max_components
-        ]
+        # Safeguard explained_variance_ratio_ calculation
+        # sort evals in descending order
+        sorted_evals = np.sort(evals)[::-1]
+        sum_evals = np.sum(sorted_evals)
+        if sum_evals < 1e-10:
+            self.explained_variance_ratio_ = np.zeros_like(sorted_evals)[
+                : self._max_components
+            ]
+        else:
+            self.explained_variance_ratio_ = (sorted_evals / sum_evals)[
+                : self._max_components
+            ]
         evecs = evecs[:, np.argsort(evals)[::-1]]  # sort eigenvectors
 
         self.scalings_ = evecs
@@ -626,9 +635,22 @@ class LinearDiscriminantAnalysis(
         if self._max_components == 0:
             self.explained_variance_ratio_ = xp.empty((0,), dtype=S.dtype)
         else:
-            self.explained_variance_ratio_ = (S**2 / xp.sum(S**2))[
-                : self._max_components
-            ]
+            # Safeguard explained_variance_ratio_ calculation
+            sum_S_sq = xp.sum(S**2)
+            if sum_S_sq < 1e-10:
+                # Create an array of zeros with the same shape and type as S would have
+                # if S was not empty, then take the slice.
+                # This handles the case where S might be empty or all zeros.
+                if size(S) > 0:
+                    self.explained_variance_ratio_ = xp.zeros_like(S**2)[
+                        : self._max_components
+                    ]
+                else:  # S is empty
+                    self.explained_variance_ratio_ = xp.empty((0,), dtype=S.dtype)
+            else:
+                self.explained_variance_ratio_ = (S**2 / sum_S_sq)[
+                    : self._max_components
+                ]
 
         rank = xp.sum(xp.astype(S > self.tol * S[0], xp.int32))
         self.scalings_ = scalings @ Vt.T[:, :rank]
@@ -924,7 +946,9 @@ class LinearDiscriminantAnalysis(
         Sb = St - Sw
 
         if self.solver in ["svd", "eigen"]:
-            evals, evecs = linalg.eigh(Sb, Sw)
+            # Add regularization to Sw for numerical stability
+            Sw_reg = Sw + np.eye(Sw.shape[0]) * 1e-8
+            evals, evecs = linalg.eigh(Sb, Sw_reg)
             order = np.argsort(evals)[::-1]
             evals = evals[order]
             evecs = evecs[:, order]
@@ -938,9 +962,16 @@ class LinearDiscriminantAnalysis(
                     )
                 self._max_components = self.n_components
             self.scalings_ = evecs
-            self.explained_variance_ratio_ = (evals / np.sum(evals))[
-                : self._max_components
-            ]
+            # Safeguard explained_variance_ratio_ calculation
+            sum_evals = np.sum(evals)
+            if sum_evals < 1e-10:
+                self.explained_variance_ratio_ = np.zeros_like(evals)[
+                    : self._max_components
+                ]
+            else:
+                self.explained_variance_ratio_ = (evals / sum_evals)[
+                    : self._max_components
+                ]
             if self.solver == "svd":
                 coef = (self.means_ - self.xbar_) @ evecs
                 self.intercept_ = -0.5 * np.sum(coef**2, axis=1) + np.log(self.priors_)


### PR DESCRIPTION
This commit introduces safeguards in LinearDiscriminantAnalysis to prevent RuntimeWarnings related to division by zero or invalid values, particularly during `partial_fit` and in the calculation of `explained_variance_ratio_`.

Changes include:
- In `_update_from_partial` (used by `partial_fit`):
    - Regularized the within-class scatter matrix (Sw) by adding a small epsilon (1e-8) to its diagonal before the eigenvalue decomposition. This improves numerical stability when Sw might be singular or ill-conditioned (e.g., when a class has few samples or zero variance).
    - Ensured safe calculation of `explained_variance_ratio_` by checking if the sum of eigenvalues is close to zero, preventing division by zero.
- In `_solve_eigen` and `_solve_svd` methods:
    - Ensured safe calculation of `explained_variance_ratio_` by checking if the sum of eigenvalues (or squared singular values for SVD) is close to zero.

These changes address warnings observed during testing and improve the robustness of LDA, especially when using `partial_fit` with classes that may initially have zero variance. All relevant unit tests continue to pass.

<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->


#### What does this implement/fix? Explain your changes.


#### Any other comments?


<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
https://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
