### PR TITLE
Add incremental LDA auto shrinkage support

### DIFF
--- a/doc/modules/lda_qda.rst
+++ b/doc/modules/lda_qda.rst
@@ -27,7 +27,10 @@ same API as the batch estimator and updates class statistics through
 :meth:`~discriminant_analysis.IncrementalLinearDiscriminantAnalysis.partial_fit`
 calls on successive mini-batches. All three solvers (``'svd'``, ``'lsqr'`` and
 ``'eigen'``) are supported, enabling streaming classification and incremental
-dimensionality reduction without storing past samples.
+dimensionality reduction without storing past samples. Shrinkage with
+``shrinkage='auto'`` for the ``'lsqr'`` and ``'eigen'`` solvers relies on a
+rolling buffer of recent residuals to approximate the Ledoit-Wolf coefficient in
+an online fashion.
 
 .. |ldaqda| image:: ../auto_examples/classification/images/sphx_glr_plot_lda_qda_001.png
         :target: ../auto_examples/classification/plot_lda_qda.html

--- a/doc/whats_new/upcoming_changes/sklearn.discriminant_analysis/00000.feature.rst
+++ b/doc/whats_new/upcoming_changes/sklearn.discriminant_analysis/00000.feature.rst
@@ -1,4 +1,6 @@
 - Added :class:`~sklearn.discriminant_analysis.IncrementalLinearDiscriminantAnalysis`,
   an incremental variant of linear discriminant analysis supporting streaming
   updates via :meth:`partial_fit` with the ``'svd'``, ``'lsqr'``, and ``'eigen'``
-  solvers.
+  solvers. The ``'lsqr'`` and ``'eigen'`` solvers include support for
+  ``shrinkage='auto'`` using a streaming Ledoit-Wolf estimate derived from a
+  rolling residual buffer.


### PR DESCRIPTION
## Summary
- extend IncrementalLinearDiscriminantAnalysis with streaming Ledoit-Wolf shrinkage buffers and pooled covariance recomputation for the lsqr and eigen solvers
- update solver logic, metadata handling, and statistics management to keep coefficients, priors, and covariances consistent after partial_fit updates
- document the new incremental estimator capabilities and cover the auto-shrinkage path with parity tests against batch LDA

## Testing
- `pytest sklearn/tests/test_incremental_lda.py -q`
- `ruff check sklearn`
- `mypy sklearn` *(fails: numpy stubs missing ComplexWarning / VisibleDeprecationWarning in sklearn/utils/fixes.py)*

------
https://chatgpt.com/codex/tasks/task_e_68d1c6a48f2c83249fe01c8deeac74c9